### PR TITLE
Update server.py compatible with mac m1

### DIFF
--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -80,7 +80,7 @@ def set_limit_memory_hard():
     if os.name == 'posix' and config['limit_memory_hard']:
         rlimit = resource.RLIMIT_RSS if platform.system() == 'Darwin' else resource.RLIMIT_AS
         soft, hard = resource.getrlimit(rlimit)
-        resource.setrlimit(rlimit, (config['limit_memory_hard'], hard))
+#        resource.setrlimit(rlimit, (config['limit_memory_hard'], hard))
 
 def empty_pipe(fd):
     try:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
def set_limit_memory_hard()

Current behavior before PR:
def set_limit_memory_hard(): give error when run

Desired behavior after PR is merged:
comments a line in the func


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
